### PR TITLE
added support for multitesting (tox) and travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+# Config file for automatic testing at travis-ci.org
+
+language: python
+
+python:
+  - "2.7"
+  - "pypy"
+
+# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+install: pip install -r requirements.txt
+
+# command to run tests, e.g. python setup.py test
+script: python setup.py nosetest

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -118,7 +118,7 @@ Cheddar uses `gitflow`_ for its branch management.
  
 4. Update the change log appropriately.
 
-5. The pull request should work for Python 2.6, 2.7, Check 
+5. The pull request should work for Python 2.7 and PyPy Check
    https://travis-ci.org/jessemyers/cheddar/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Flask>=0.10
+redis>=2.8.0
+requests>=2.0.0
+BeautifulSoup>=3.2.1
+python-magic>=0.4.6
+pkginfo>=1.1
+mock>=1.0.1
+mockredispy>=2.7.5.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist =  py27, pypy
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}/cheddar
+commands = python setup.py nosetests
+deps =
+    -r{toxinidir}/requirements.txt


### PR DESCRIPTION
- added support for multitesting (tox) and travis CI
- added requirements.txt to make it easier on travis and tox.
- removed python 2.6 from contributing as its not working at all and
  its outside of the scope of this feature to fix that.
