### PR TITLE
Workaround for pip install package name normalizatoin

### DIFF
--- a/cheddar/index/local.py
+++ b/cheddar/index/local.py
@@ -4,7 +4,7 @@ Implements a local package index.
 from os.path import basename
 from time import time
 
-from werkzeug import secure_filename
+from werkzeug.utils import secure_filename
 
 from cheddar.exceptions import BadRequestError, ConflictError, NotFoundError
 from cheddar.index.index import Index
@@ -35,7 +35,11 @@ class LocalIndex(Index):
     def get_versions(self, name):
         self.logger.info("Getting local versions listing for: {}".format(name))
 
-        project = self.projects.get_project(name)
+        # Pip converts underscores to dashes in distribution names. e.g. Pip will search for
+        # foo-bar when the dist name is foo_bar. Workaround by searching for both names here
+        # instead of normalizing the name on package registration and upload.
+        project = (self.projects.get_project(name) or
+                   self.projects.get_project(name.replace("-", "_")))
         if project is None:
             return None
 

--- a/cheddar/model/versions.py
+++ b/cheddar/model/versions.py
@@ -78,7 +78,7 @@ def is_pre_release(basename):
 
     def is_patch(part):
         # the tailing "-" is important here
-        return part == "*final-"
+        return part == "*post" or part == "*final-"
 
     # strip out patch levels indicator and their successive qualifier
     parts = [part for index, part in enumerate(parsed_version)

--- a/cheddar/tests/model/test_versions.py
+++ b/cheddar/tests/model/test_versions.py
@@ -78,7 +78,7 @@ def test_name_match():
 def test_is_pre_release():
 
     def validate_is_pre_release(basename, expected):
-        eq_(is_pre_release(basename), expected)
+        eq_(is_pre_release(basename), expected, basename)
 
     cases = [("foo-1.1", False),
              ("foo-1.0.1", False),


### PR DESCRIPTION
Pip 8.0.0+ no longer has fallback for unnormalized distribution names.  This adds a quick workaround for pip installs without having to add name normalization logic and fixing existing distributions.
